### PR TITLE
Tidy up code results outputting:

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -163,3 +163,4 @@ docs/report/*.pdf
 
 # Custom entries:
 samples/
+scans/

--- a/src/main.py
+++ b/src/main.py
@@ -22,10 +22,9 @@ if os.getcwd() not in sys.path:
 
 import argparse
 
-import input
 import output
-from src.scanning import scan
 from src.ocr import extract
+from src.scanning import scan
 
 
 def setup_cli():

--- a/src/main.py
+++ b/src/main.py
@@ -28,29 +28,44 @@ from src.scanning import scan
 from src.ocr import extract
 
 
-def main():
+def setup_cli():
     # construct the argument parser and parse the arguments
     ap = argparse.ArgumentParser()
     ap.add_argument("image_path",
                     help="Path to the image to be scanned")
+
+    return ap
+
+
+def main():
+    ap = setup_cli()
     args = vars(ap.parse_args())
 
     img_path = args["image_path"]
 
+    # Scan the image
     scanned_img = scan.scan(img_path)
+    scan_save_path = output.get_save_path(img_path)
 
-    orig = input.read_image(img_path)
-    scan_path = output.save(orig, scanned_img)
+    success = output.save_img(scanned_img, scan_save_path)
+    if not success:
+        print(f"Could not save image to path '{scan_save_path}'")
+        sys.exit(1)
 
     # OCR:
-    text = extract.extract_text(scan_path)
+    text = extract.extract_text(scan_save_path)
 
-    with open("./out/output.txt", "w") as f:
+    _, fname, _ = output.deconstruct_img_path(img_path)
+    text_path = os.path.join(output.save_dir(), fname + ".txt")
+
+    with open(text_path, "w") as f:
         f.write(text)
-    print("OUTPUT:")
+
+    print("Scan Text Result:")
     print(text)
 
-    extract.extract_to_pdf(scan_path)
+    pdf_path = os.path.join(output.save_dir(), fname + ".pdf")
+    extract.extract_to_pdf(scan_save_path, pdf_path)
 
 
 if __name__ == "__main__":

--- a/src/ocr/extract.py
+++ b/src/ocr/extract.py
@@ -24,11 +24,11 @@ def extract_text(image_path):
     return output
 
 
-def extract_to_pdf(image_path):
+def extract_to_pdf(image_path, pdf_save_path):
     image = PIL.Image.open(image_path)
 
     PDF = pytesseract.image_to_pdf_or_hocr(
         image, lang='eng', config='', nice=0, extension='pdf')
 
-    with open("./out/demofile.pdf", "w+b") as f:
+    with open(pdf_save_path, "w+b") as f:
         f.write(bytearray(PDF))

--- a/src/output.py
+++ b/src/output.py
@@ -14,20 +14,37 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 import cv2
 import imutils
+import os
 
 
-def save(orig, warped):
-    # show the original and scanned images
-    write_success = cv2.imwrite(
-        "./out/original.JPEG", imutils.resize(orig, height=650))
-    if not write_success:
-        print("Could not write original image!")
+def save_dir():
+    return os.path.join(os.getcwd(), "scans")
 
-    scan_path = "./out/scanned.JPEG"
 
-    write_success = cv2.imwrite(
-        scan_path, imutils.resize(warped, height=650))
-    if not write_success:
-        print("Could not write scanned image!")
+def deconstruct_img_path(img_path):
+    dir, basename = os.path.split(img_path)
+    fname, extension = os.path.splitext(basename)
 
-    return scan_path
+    return dir, fname, extension
+
+
+def get_save_path(img_path):
+    _, fname, extension = deconstruct_img_path(img_path)
+
+    save_fname = fname + "-scan"
+
+    return os.path.join(save_dir(), save_fname + extension)
+
+
+def _ensure_path_exists(save_path):
+    dirs, fname = os.path.split(save_path)
+    if not os.path.exists(dirs):
+        os.makedirs(dirs)
+
+
+def save_img(img, save_path):
+    # Resize the image
+    resized = imutils.resize(img, height=650)
+    _ensure_path_exists(save_path)
+
+    return cv2.imwrite(save_path, resized)


### PR DESCRIPTION
Change the code to output all scan results to a `scans/` dir that is
marked by .gitignore.

The code produces a scanned image, scanned pdf and the text content of
the image into that dir using the same name as the input image.

Tidy up some of the CLI setup while achieving this.
